### PR TITLE
Director thumbs

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -13,3 +13,9 @@
  *= require_tree .
  *= require_self
  */
+
+.director-thumbnail {
+  max-width: 150px;
+}
+
+

--- a/app/views/directors/index.html.erb
+++ b/app/views/directors/index.html.erb
@@ -2,6 +2,7 @@
 
 <% @directors.each do |director| %>
  <div id="director-<%= director.id %>">
+   <img src="<%= director.thumbnail %>" alt="<%= director.name %> thumbnail">
    <h2><%= director.name %></h2>
    <p><%= director.age %></p>
    <p><%= director.city %></p>

--- a/app/views/directors/index.html.erb
+++ b/app/views/directors/index.html.erb
@@ -1,14 +1,14 @@
 <h1>All Game of Thrones Episode Directors</h1>
 
 <% @directors.each do |director| %>
- <div id="director-<%= director.id %>">
-   <img src="<%= director.thumbnail %>" alt="<%= director.name %> thumbnail">
+ <div class="director-card" id="director-<%= director.id %>">
+   <img class="director-thumbnail" src="<%= director.thumbnail %>" alt="<%= director.name %> thumbnail"/>
    <h2><%= director.name %></h2>
    <p><%= director.age %></p>
    <p><%= director.city %></p>
 
    <% director.episodes.each do |episode| %>
-    <div id="episode-<%= episode.id %>">
+    <div class="episode-card" id="episode-<%= episode.id %>">
       <h3><%= episode.title %></h3>
       <p><%= episode.viewers %> million viewers</p>
     </div>

--- a/db/migrate/20190501215820_add_thumbnail_to_directors.rb
+++ b/db/migrate/20190501215820_add_thumbnail_to_directors.rb
@@ -1,0 +1,5 @@
+class AddThumbnailToDirectors < ActiveRecord::Migration[5.1]
+  def change
+    add_column :directors, :thumbnail, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190501204547) do
+ActiveRecord::Schema.define(version: 20190501215820) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -21,6 +21,7 @@ ActiveRecord::Schema.define(version: 20190501204547) do
     t.string "city"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "thumbnail"
   end
 
   create_table "episodes", force: :cascade do |t|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -9,9 +9,9 @@
 Episode.destroy_all
 Director.destroy_all
 
-tim_van_p = Director.create(name: "Tim Van Patten", age: 59, city: "Brooklyn, NY, USA")
-brian_kirk = Director.create(name: "Brian Kirk", age: 50, city: "Armagh, Northern Ireland, UK")
-alan_taylor = Director.create(name: "Alan Taylor", age: 59, city: "Brooklyn, NY, USA")
+tim_van_p = Director.create(name: "Tim Van Patten", age: 59, city: "Brooklyn, NY, USA", thumbnail: "https://resizing.flixster.com/QznwomaCPPn2qLY4qGQhpkkv95s=/679x605/v1.cjs0MzE2MjtqOzE4MDQ1OzEyMDA7Njc5OzYwNQ")
+brian_kirk = Director.create(name: "Brian Kirk", age: 50, city: "Armagh, Northern Ireland, UK", thumbnail: "https://thefilmstage.com/wp-content/uploads/2012/02/Brian-Kirk-to-Direct-Thor-2-300x218.jpg")
+alan_taylor = Director.create(name: "Alan Taylor", age: 59, city: "Brooklyn, NY, USA", thumbnail: "https://upload.wikimedia.org/wikipedia/commons/thumb/5/54/Alan_Taylor_2013_crop.jpg/440px-Alan_Taylor_2013_crop.jpg")
 
 tim_van_p.episodes.create(title: "Winter is Coming", viewers: 2)
 tim_van_p.episodes.create(title: "The Kingsroad", viewers: 2)

--- a/spec/features/directors/index_spec.rb
+++ b/spec/features/directors/index_spec.rb
@@ -51,15 +51,6 @@ RSpec.describe "directors index page", type: :feature do
     within "#director-#{@dir_2.id}" do
       expect(page).to have_xpath("//img[@src='#{@dir_2.thumbnail}']")
     end
-
-    #     User Story 3
-    #
-    # As a visitor
-    # When I visit `/comedians`
-    # I see a thumbnail image for each comedian
-    #
-    # - Image locations (URLs) can be stored in the database as a string.
-    # - Use the image URLs from IMDB or other online source for the special
     # - Use CSS styling to scale the image smaller if needed to fit on the page
   end
 end

--- a/spec/features/directors/index_spec.rb
+++ b/spec/features/directors/index_spec.rb
@@ -2,8 +2,8 @@ require 'rails_helper'
 
 RSpec.describe "directors index page", type: :feature do
   before(:each) do
-    @dir_1 = Director.create(name: "Bob Director", age: 50, city: "Chicago, IL")
-    @dir_2 = Director.create(name: "Susan Blah", age: 42, city: "Los Angeles, CA")
+    @dir_1 = Director.create(name: "Bob Director", age: 50, city: "Chicago, IL", thumbnail: "https://resizing.flixster.com/QznwomaCPPn2qLY4qGQhpkkv95s=/679x605/v1.cjs0MzE2MjtqOzE4MDQ1OzEyMDA7Njc5OzYwNQ")
+    @dir_2 = Director.create(name: "Susan Blah", age: 42, city: "Los Angeles, CA", thumbnail: "https://thefilmstage.com/wp-content/uploads/2012/02/Brian-Kirk-to-Direct-Thor-2-300x218.jpg")
     @eps_1 = @dir_1.episodes.create(title: "The Red Wedding", viewers: 10)
     @eps_2 = @dir_1.episodes.create(title: "Battle of the Bastards", viewers: 12)
     @eps_3 = @dir_2.episodes.create(title: "Black Water Bay", viewers: 9)
@@ -39,5 +39,27 @@ RSpec.describe "directors index page", type: :feature do
       expect(page).to have_content(@eps_3.title)
       expect(page).to have_content("#{@eps_3.viewers} million viewers")
     end
+  end
+
+  it "user can see thumbnail for each director" do
+    visit "/directors"
+
+    within "#director-#{@dir_1.id}" do
+      expect(page).to have_xpath("//img[@src='#{dir_1.thumbnail}']")
+    end
+
+    within "#director-#{@dir_2.id}" do
+      expect(page).to have_xpath("//img[@src='#{dir_2.thumbnail}']")
+    end
+
+    #     User Story 3
+    #
+    # As a visitor
+    # When I visit `/comedians`
+    # I see a thumbnail image for each comedian
+    #
+    # - Image locations (URLs) can be stored in the database as a string.
+    # - Use the image URLs from IMDB or other online source for the special
+    # - Use CSS styling to scale the image smaller if needed to fit on the page
   end
 end

--- a/spec/features/directors/index_spec.rb
+++ b/spec/features/directors/index_spec.rb
@@ -45,11 +45,11 @@ RSpec.describe "directors index page", type: :feature do
     visit "/directors"
 
     within "#director-#{@dir_1.id}" do
-      expect(page).to have_xpath("//img[@src='#{dir_1.thumbnail}']")
+      expect(page).to have_xpath("//img[@src='#{@dir_1.thumbnail}']")
     end
 
     within "#director-#{@dir_2.id}" do
-      expect(page).to have_xpath("//img[@src='#{dir_2.thumbnail}']")
+      expect(page).to have_xpath("//img[@src='#{@dir_2.thumbnail}']")
     end
 
     #     User Story 3

--- a/spec/features/directors/index_spec.rb
+++ b/spec/features/directors/index_spec.rb
@@ -1,44 +1,43 @@
 require 'rails_helper'
 
 RSpec.describe "directors index page", type: :feature do
-  it "user can see all directors" do
-    dir_1 = Director.create(name: "Bob Director", age: 50, city: "Chicago, IL")
-    dir_2 = Director.create(name: "Susan Blah", age: 42, city: "Los Angeles, CA")
+  before(:each) do
+    @dir_1 = Director.create(name: "Bob Director", age: 50, city: "Chicago, IL")
+    @dir_2 = Director.create(name: "Susan Blah", age: 42, city: "Los Angeles, CA")
+    @eps_1 = @dir_1.episodes.create(title: "The Red Wedding", viewers: 10)
+    @eps_2 = @dir_1.episodes.create(title: "Battle of the Bastards", viewers: 12)
+    @eps_3 = @dir_2.episodes.create(title: "Black Water Bay", viewers: 9)
+  end
 
+  it "user can see all directors" do
     visit "/directors"
 
-    within "#director-#{dir_1.id}" do
-      expect(page).to have_content(dir_1.name)
-      expect(page).to have_content(dir_1.age)
-      expect(page).to have_content(dir_1.city)
+    within "#director-#{@dir_1.id}" do
+      expect(page).to have_content(@dir_1.name)
+      expect(page).to have_content(@dir_1.age)
+      expect(page).to have_content(@dir_1.city)
     end
 
-    within "#director-#{dir_2.id}" do
-      expect(page).to have_content(dir_2.name)
-      expect(page).to have_content(dir_2.age)
-      expect(page).to have_content(dir_2.city)
+    within "#director-#{@dir_2.id}" do
+      expect(page).to have_content(@dir_2.name)
+      expect(page).to have_content(@dir_2.age)
+      expect(page).to have_content(@dir_2.city)
     end
   end
 
   it "user can see episodes for each director" do
-    dir_1 = Director.create(name: "Bob Director", age: 50, city: "Chicago, IL")
-    dir_2 = Director.create(name: "Susan Blah", age: 42, city: "Los Angeles, CA")
-    eps_1 = dir_1.episodes.create(title: "The Red Wedding", viewers: 10)
-    eps_2 = dir_1.episodes.create(title: "Battle of the Bastards", viewers: 12)
-    eps_3 = dir_2.episodes.create(title: "Black Water Bay", viewers: 9)
-
     visit "/directors"
 
-    within "#director-#{dir_1.id}" do
-      expect(page).to have_content(eps_1.title)
-      expect(page).to have_content("#{eps_1.viewers} million viewers")
-      expect(page).to have_content(eps_2.title)
-      expect(page).to have_content("#{eps_2.viewers} million viewers")
+    within "#director-#{@dir_1.id}" do
+      expect(page).to have_content(@eps_1.title)
+      expect(page).to have_content("#{@eps_1.viewers} million viewers")
+      expect(page).to have_content(@eps_2.title)
+      expect(page).to have_content("#{@eps_2.viewers} million viewers")
     end
 
-    within "#director-#{dir_2.id}" do
-      expect(page).to have_content(eps_3.title)
-      expect(page).to have_content("#{eps_3.viewers} million viewers")
+    within "#director-#{@dir_2.id}" do
+      expect(page).to have_content(@eps_3.title)
+      expect(page).to have_content("#{@eps_3.viewers} million viewers")
     end
   end
 end

--- a/spec/features/directors/index_spec.rb
+++ b/spec/features/directors/index_spec.rb
@@ -51,6 +51,5 @@ RSpec.describe "directors index page", type: :feature do
     within "#director-#{@dir_2.id}" do
       expect(page).to have_xpath("//img[@src='#{@dir_2.thumbnail}']")
     end
-    # - Use CSS styling to scale the image smaller if needed to fit on the page
   end
 end


### PR DESCRIPTION
This PR/branch...
 - Adds a before(:each) to directors/index_spec to DRY up the tests
 - Adds a `thumbnail` column (as a string - URL) to the `directors` table and seeds the DB accordingly
 - Displays the thumbnails on `directors/index.html.erb` (up to a max width)
 - Adds classes to the HTML tags on `directors/index.html.erb`