### PR TITLE
Filter by age

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -41,3 +41,8 @@ h1 {
   flex: 0 0 100%;
   max-width: 100%;
 }
+
+#no-directors-found {
+  color: #ce8923;
+  padding: 10px;
+}

--- a/app/controllers/directors_controller.rb
+++ b/app/controllers/directors_controller.rb
@@ -1,5 +1,10 @@
 class DirectorsController < ApplicationController
   def index
-    @directors = Director.all
+    age = params[:age]
+    if age.nil?
+      @directors = Director.all
+    else
+      @directors = Director.filter_by_age(age)
+    end
   end
 end

--- a/app/models/director.rb
+++ b/app/models/director.rb
@@ -1,8 +1,12 @@
 class Director < ApplicationRecord
   has_many :episodes
-  
+
   validates_presence_of :name
   # TO DO: below - change to birth_year and calculate the age
   validates_presence_of :age
   validates_presence_of :city
+
+  def self.filter_by_age(age)
+    self.all.where(age: age.to_i)
+  end
 end

--- a/app/views/directors/index.html.erb
+++ b/app/views/directors/index.html.erb
@@ -2,6 +2,13 @@
   <h1>Game of Thrones - Directors</h1>
 </header>
 
+<% if @directors.count == 0 %>
+ <div id="no-directors-found">
+   <p>No directors found with those criteria.</p>
+   <%= link_to "Back to all directors", "/directors"%>
+ </div>
+<% end %>
+
 <div class="card-deck">
   <% @directors.each do |director| %>
     <div class="card director-card" id="director-<%= director.id %>">

--- a/spec/features/directors/index_spec.rb
+++ b/spec/features/directors/index_spec.rb
@@ -54,6 +54,16 @@ RSpec.describe "directors index page", type: :feature do
     end
   end
 
+  # User Story 4
+  #
+  # As a visitor
+  # When I visit `/comedians?age=34`
+  # Then I see the list of comedians on the page only shows
+  # comedians who match the age criteria.
+  #
+  # - All other information on the page is still expected to be present
+  # - Testing should check that excluded comedians do not show up.
+
   it "user can see episode count for each director" do
     visit "/directors"
 
@@ -69,52 +79,41 @@ RSpec.describe "directors index page", type: :feature do
       expect(page).to have_no_content("Episodes")
     end
   end
+
+  # User Story 6
+  #
+  # As a visitor
+  # When I visit `/comedians/new`
+  # Then I see a form to input a new comedian into the database
+  # Including fields for their name, age and city.
+  # When the form is successfully submitted and saved,
+  # Then I am redirected to `/comedians`
+  # And I see the new comedian's data on the page.
+
+
+  # User Story 7
+  #
+  # As a visitor
+  # When I visit `/comedians`
+  # Then I see an area at the top of the page called 'Statistics'
+  # In that 'Statistics' area, I see the following information:
+  # - the average age of all comedians on the page (if the page is filtered for specific comedians, the statistics should reflect the new group)
+  # - a unique list of cities for each comedian on the page
+  #
+  # Averaging and uniqueness should be done in ActiveRecord NOT
+  # using Ruby
+
+
+  # User Story 8
+  #
+  # As a visitor
+  # When I visit `/comedians?age=34`
+  # Then I see a list of all comedians with an age of 34
+  # Just like a previous User Story, BUT all other statistics
+  # information in the 'Statistics' area of the page should be limited
+  # to reflect only the information about the comedians listed on
+  # the page.
+  #
+  # - Testing should ensure that calculated statistics are
+  #   correct for a limited subset of data
 end
-
-# User Story 4
-#
-# As a visitor
-# When I visit `/comedians?age=34`
-# Then I see the list of comedians on the page only shows
-# comedians who match the age criteria.
-#
-# - All other information on the page is still expected to be present
-# - Testing should check that excluded comedians do not show up.
-
-
-# User Story 6
-#
-# As a visitor
-# When I visit `/comedians/new`
-# Then I see a form to input a new comedian into the database
-# Including fields for their name, age and city.
-# When the form is successfully submitted and saved,
-# Then I am redirected to `/comedians`
-# And I see the new comedian's data on the page.
-
-
-# User Story 7
-#
-# As a visitor
-# When I visit `/comedians`
-# Then I see an area at the top of the page called 'Statistics'
-# In that 'Statistics' area, I see the following information:
-# - the average age of all comedians on the page (if the page is filtered for specific comedians, the statistics should reflect the new group)
-# - a unique list of cities for each comedian on the page
-#
-# Averaging and uniqueness should be done in ActiveRecord NOT
-# using Ruby
-
-
-# User Story 8
-#
-# As a visitor
-# When I visit `/comedians?age=34`
-# Then I see a list of all comedians with an age of 34
-# Just like a previous User Story, BUT all other statistics
-# information in the 'Statistics' area of the page should be limited
-# to reflect only the information about the comedians listed on
-# the page.
-#
-# - Testing should ensure that calculated statistics are
-#   correct for a limited subset of data

--- a/spec/features/directors/index_spec.rb
+++ b/spec/features/directors/index_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe "directors index page", type: :feature do
   it "user can filter to directors with only a spec'd age" do
     Episode.destroy_all
     Director.destroy_all
-    
+
     dir_4 = Director.create(name: "Bob Director", age: 50, city: "Chicago, IL", thumbnail: "https://resizing.flixster.com/QznwomaCPPn2qLY4qGQhpkkv95s=/679x605/v1.cjs0MzE2MjtqOzE4MDQ1OzEyMDA7Njc5OzYwNQ")
     dir_5 = Director.create(name: "Susan Blah", age: 42, city: "Los Angeles, CA", thumbnail: "https://thefilmstage.com/wp-content/uploads/2012/02/Brian-Kirk-to-Direct-Thor-2-300x218.jpg")
     dir_6 = Director.create(name: "Mike McDonald", age: 50, city: "Los Angeles, CA", thumbnail: "https://upload.wikimedia.org/wikipedia/commons/thumb/5/54/Alan_Taylor_2013_crop.jpg/440px-Alan_Taylor_2013_crop.jpg")
@@ -67,6 +67,23 @@ RSpec.describe "directors index page", type: :feature do
     expect(page).to have_content(dir_4.name)
     expect(page).to_not have_content(dir_5.name)
     expect(page).to have_content(dir_6.name)
+  end
+
+  it "user can see a message if no directors have spec'd age" do
+    Episode.destroy_all
+    Director.destroy_all
+
+    dir_4 = Director.create(name: "Bob Director", age: 50, city: "Chicago, IL", thumbnail: "https://resizing.flixster.com/QznwomaCPPn2qLY4qGQhpkkv95s=/679x605/v1.cjs0MzE2MjtqOzE4MDQ1OzEyMDA7Njc5OzYwNQ")
+    dir_5 = Director.create(name: "Susan Blah", age: 42, city: "Los Angeles, CA", thumbnail: "https://thefilmstage.com/wp-content/uploads/2012/02/Brian-Kirk-to-Direct-Thor-2-300x218.jpg")
+    dir_6 = Director.create(name: "Mike McDonald", age: 50, city: "Los Angeles, CA", thumbnail: "https://upload.wikimedia.org/wikipedia/commons/thumb/5/54/Alan_Taylor_2013_crop.jpg/440px-Alan_Taylor_2013_crop.jpg")
+
+    visit "/directors?age=11"
+
+    expect(page).to_not have_content(dir_4.name)
+    expect(page).to_not have_content(dir_5.name)
+    expect(page).to_not have_content(dir_6.name)
+    expect(page).to have_content("No directors found with those criteria.")
+    expect(page).to have_link("Back to all directors")
   end
 
   it "user can see episode count for each director" do

--- a/spec/features/directors/index_spec.rb
+++ b/spec/features/directors/index_spec.rb
@@ -54,7 +54,10 @@ RSpec.describe "directors index page", type: :feature do
     end
   end
 
-  it "user can see episode count for each director" do
+  it "user can filter to directors with only a spec'd age" do
+    Episode.destroy_all
+    Director.destroy_all
+    
     dir_4 = Director.create(name: "Bob Director", age: 50, city: "Chicago, IL", thumbnail: "https://resizing.flixster.com/QznwomaCPPn2qLY4qGQhpkkv95s=/679x605/v1.cjs0MzE2MjtqOzE4MDQ1OzEyMDA7Njc5OzYwNQ")
     dir_5 = Director.create(name: "Susan Blah", age: 42, city: "Los Angeles, CA", thumbnail: "https://thefilmstage.com/wp-content/uploads/2012/02/Brian-Kirk-to-Direct-Thor-2-300x218.jpg")
     dir_6 = Director.create(name: "Mike McDonald", age: 50, city: "Los Angeles, CA", thumbnail: "https://upload.wikimedia.org/wikipedia/commons/thumb/5/54/Alan_Taylor_2013_crop.jpg/440px-Alan_Taylor_2013_crop.jpg")

--- a/spec/features/directors/index_spec.rb
+++ b/spec/features/directors/index_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe "directors index page", type: :feature do
   before(:each) do
     @dir_1 = Director.create(name: "Bob Director", age: 50, city: "Chicago, IL", thumbnail: "https://resizing.flixster.com/QznwomaCPPn2qLY4qGQhpkkv95s=/679x605/v1.cjs0MzE2MjtqOzE4MDQ1OzEyMDA7Njc5OzYwNQ")
     @dir_2 = Director.create(name: "Susan Blah", age: 42, city: "Los Angeles, CA", thumbnail: "https://thefilmstage.com/wp-content/uploads/2012/02/Brian-Kirk-to-Direct-Thor-2-300x218.jpg")
-    @dir_3 = Director.create(name: "Mike McDonald", age: 30, city: "Los Angeles, CA", thumbnail: "https://upload.wikimedia.org/wikipedia/commons/thumb/5/54/Alan_Taylor_2013_crop.jpg/440px-Alan_Taylor_2013_crop.jpg")
+    @dir_3 = Director.create(name: "Mike McDonald", age: 50, city: "Los Angeles, CA", thumbnail: "https://upload.wikimedia.org/wikipedia/commons/thumb/5/54/Alan_Taylor_2013_crop.jpg/440px-Alan_Taylor_2013_crop.jpg")
     @eps_1 = @dir_1.episodes.create(title: "The Red Wedding", viewers: 10)
     @eps_2 = @dir_1.episodes.create(title: "Battle of the Bastards", viewers: 12)
     @eps_3 = @dir_2.episodes.create(title: "Black Water Bay", viewers: 9)
@@ -54,15 +54,17 @@ RSpec.describe "directors index page", type: :feature do
     end
   end
 
-  # User Story 4
-  #
-  # As a visitor
-  # When I visit `/comedians?age=34`
-  # Then I see the list of comedians on the page only shows
-  # comedians who match the age criteria.
-  #
-  # - All other information on the page is still expected to be present
-  # - Testing should check that excluded comedians do not show up.
+  it "user can see episode count for each director" do
+    dir_4 = Director.create(name: "Bob Director", age: 50, city: "Chicago, IL", thumbnail: "https://resizing.flixster.com/QznwomaCPPn2qLY4qGQhpkkv95s=/679x605/v1.cjs0MzE2MjtqOzE4MDQ1OzEyMDA7Njc5OzYwNQ")
+    dir_5 = Director.create(name: "Susan Blah", age: 42, city: "Los Angeles, CA", thumbnail: "https://thefilmstage.com/wp-content/uploads/2012/02/Brian-Kirk-to-Direct-Thor-2-300x218.jpg")
+    dir_6 = Director.create(name: "Mike McDonald", age: 50, city: "Los Angeles, CA", thumbnail: "https://upload.wikimedia.org/wikipedia/commons/thumb/5/54/Alan_Taylor_2013_crop.jpg/440px-Alan_Taylor_2013_crop.jpg")
+
+    visit "/directors?age=50"
+
+    expect(page).to have_content(dir_4.name)
+    expect(page).to_not have_content(dir_5.name)
+    expect(page).to have_content(dir_6.name)
+  end
 
   it "user can see episode count for each director" do
     visit "/directors"


### PR DESCRIPTION
This PR/branch...
 - Completes User Story 4
 - Allows for filtering of Directors by age (using query params)
 - Displays a message (& link back to full list) if no directors match the query params