### PR TITLE
Birth year

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -64,3 +64,8 @@ h1 {
   background-color: #c4c4c4;
   padding: 10px;
 }
+
+#failed-to-create {
+  color: white;
+  padding: 10px;
+}

--- a/app/controllers/directors_controller.rb
+++ b/app/controllers/directors_controller.rb
@@ -18,8 +18,7 @@ class DirectorsController < ApplicationController
 
   def create
     director = Director.new(director_params)
-    creation_result = director.save
-    if creation_result
+    if director.save
       redirect_to "/directors"
     else
       redirect_to "/directors/new?failed=true"
@@ -29,6 +28,6 @@ class DirectorsController < ApplicationController
   private
 
   def director_params
-    params.require(:director).permit(:name, :age, :city)
+    params.require(:director).permit(:name, :birth_year, :city)
   end
 end

--- a/app/models/director.rb
+++ b/app/models/director.rb
@@ -2,18 +2,18 @@ class Director < ApplicationRecord
   has_many :episodes
 
   validates_presence_of :name
-  # TO DO: below - change to birth_year and calculate the age
-  validates_presence_of :age
+  validates_presence_of :birth_year
   validates_presence_of :city
 
-  validates :age, numericality: { only_integer: true }
+  validates :birth_year, numericality: { only_integer: true }
 
   def self.filter_by_age(age)
-    self.all.where(age: age.to_i)
+    birth_year_to_find = Time.now.year - age.to_i
+    self.all.where(birth_year: birth_year_to_find.to_i)
   end
 
   def self.avg_age
-    average(:age)
+     Time.now.year - average(:birth_year)
   end
 
   def self.all_uniq_cities
@@ -21,8 +21,11 @@ class Director < ApplicationRecord
   end
 
   def age
-    current_year = Time.now.year
-    birth_year - current_year
+    if birth_year.nil?
+      nil
+    else
+      Time.now.year - birth_year
+    end
   end
 
   def episode_count

--- a/app/models/director.rb
+++ b/app/models/director.rb
@@ -20,6 +20,11 @@ class Director < ApplicationRecord
     distinct.pluck(:city).sort
   end
 
+  def age
+    current_year = Time.now.year
+    birth_year - current_year
+  end
+
   def episode_count
     episodes.count
   end

--- a/app/models/director.rb
+++ b/app/models/director.rb
@@ -13,7 +13,11 @@ class Director < ApplicationRecord
   end
 
   def self.avg_age
-     Time.now.year - average(:birth_year)
+    if count == 0
+      "N/A"
+    else
+      Time.now.year - average(:birth_year)
+    end
   end
 
   def self.all_uniq_cities

--- a/app/views/directors/new.html.erb
+++ b/app/views/directors/new.html.erb
@@ -1,5 +1,5 @@
 <% if @failed %>
-  <p>Failed to create new director. Try again.</p>
+  <p id="failed-to-create">Failed to create new director. Try again.</p>
 <% end %>
 
 <%= form_for @director do |f| %>

--- a/app/views/directors/new.html.erb
+++ b/app/views/directors/new.html.erb
@@ -10,8 +10,8 @@
     (Required)
   </small>
   <br>
-  <%= f.label :age %>
-  <%= f.text_field :age, class: 'form-control' %>
+  <%= f.label :birth_year %>
+  <%= f.text_field :birth_year, class: 'form-control' %>
   <small class="form-text text-muted">
     (Required. Please enter a whole number.)
   </small>

--- a/db/migrate/20190504030506_rename_age_column.rb
+++ b/db/migrate/20190504030506_rename_age_column.rb
@@ -1,0 +1,5 @@
+class RenameAgeColumn < ActiveRecord::Migration[5.1]
+  def change
+    rename_column(:directors, :age, :birth_year)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,14 +10,14 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190501215820) do
+ActiveRecord::Schema.define(version: 20190504030506) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "directors", force: :cascade do |t|
     t.string "name"
-    t.integer "age"
+    t.integer "birth_year"
     t.string "city"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -9,9 +9,9 @@
 Episode.destroy_all
 Director.destroy_all
 
-tim_van_p = Director.create(name: "Tim Van Patten", age: 59, city: "Brooklyn, NY, USA", thumbnail: "https://resizing.flixster.com/QznwomaCPPn2qLY4qGQhpkkv95s=/679x605/v1.cjs0MzE2MjtqOzE4MDQ1OzEyMDA7Njc5OzYwNQ")
-brian_kirk = Director.create(name: "Brian Kirk", age: 50, city: "Armagh, Northern Ireland, UK", thumbnail: "https://thefilmstage.com/wp-content/uploads/2012/02/Brian-Kirk-to-Direct-Thor-2-300x218.jpg")
-alan_taylor = Director.create(name: "Alan Taylor", age: 59, city: "Brooklyn, NY, USA", thumbnail: "https://upload.wikimedia.org/wikipedia/commons/thumb/5/54/Alan_Taylor_2013_crop.jpg/440px-Alan_Taylor_2013_crop.jpg")
+tim_van_p = Director.create(name: "Tim Van Patten", birth_year: 1959, city: "Brooklyn, NY, USA", thumbnail: "https://resizing.flixster.com/QznwomaCPPn2qLY4qGQhpkkv95s=/679x605/v1.cjs0MzE2MjtqOzE4MDQ1OzEyMDA7Njc5OzYwNQ")
+brian_kirk = Director.create(name: "Brian Kirk", birth_year: 1968, city: "Armagh, Northern Ireland, UK", thumbnail: "https://thefilmstage.com/wp-content/uploads/2012/02/Brian-Kirk-to-Direct-Thor-2-300x218.jpg")
+alan_taylor = Director.create(name: "Alan Taylor", birth_year: 1959, city: "Brooklyn, NY, USA", thumbnail: "https://upload.wikimedia.org/wikipedia/commons/thumb/5/54/Alan_Taylor_2013_crop.jpg/440px-Alan_Taylor_2013_crop.jpg")
 
 tim_van_p.episodes.create(title: "Winter is Coming", viewers: 2)
 tim_van_p.episodes.create(title: "The Kingsroad", viewers: 2)

--- a/spec/features/directors/index_spec.rb
+++ b/spec/features/directors/index_spec.rb
@@ -3,9 +3,9 @@ require 'rails_helper'
 RSpec.describe "directors index page", type: :feature do
   describe "main" do
     before(:each) do
-      @dir_1 = Director.create(name: "Bob Director", age: 50, city: "Chicago, IL", thumbnail: "https://resizing.flixster.com/QznwomaCPPn2qLY4qGQhpkkv95s=/679x605/v1.cjs0MzE2MjtqOzE4MDQ1OzEyMDA7Njc5OzYwNQ")
-      @dir_2 = Director.create(name: "Susan Blah", age: 42, city: "Los Angeles, CA", thumbnail: "https://thefilmstage.com/wp-content/uploads/2012/02/Brian-Kirk-to-Direct-Thor-2-300x218.jpg")
-      @dir_3 = Director.create(name: "Mike McDonald", age: 50, city: "Los Angeles, CA", thumbnail: "https://upload.wikimedia.org/wikipedia/commons/thumb/5/54/Alan_Taylor_2013_crop.jpg/440px-Alan_Taylor_2013_crop.jpg")
+      @dir_1 = Director.create(name: "Bob Director", birth_year: 1969, city: "Chicago, IL", thumbnail: "https://resizing.flixster.com/QznwomaCPPn2qLY4qGQhpkkv95s=/679x605/v1.cjs0MzE2MjtqOzE4MDQ1OzEyMDA7Njc5OzYwNQ")
+      @dir_2 = Director.create(name: "Susan Blah", birth_year: 1977, city: "Los Angeles, CA", thumbnail: "https://thefilmstage.com/wp-content/uploads/2012/02/Brian-Kirk-to-Direct-Thor-2-300x218.jpg")
+      @dir_3 = Director.create(name: "Mike McDonald", birth_year: 1969, city: "Los Angeles, CA", thumbnail: "https://upload.wikimedia.org/wikipedia/commons/thumb/5/54/Alan_Taylor_2013_crop.jpg/440px-Alan_Taylor_2013_crop.jpg")
       @eps_1 = @dir_1.episodes.create(title: "The Red Wedding", viewers: 10)
       @eps_2 = @dir_1.episodes.create(title: "Battle of the Bastards", viewers: 12)
       @eps_3 = @dir_2.episodes.create(title: "Black Water Bay", viewers: 9)
@@ -77,9 +77,9 @@ RSpec.describe "directors index page", type: :feature do
       Episode.destroy_all
       Director.destroy_all
 
-      @dir_4 = Director.create(name: "Bob Director", age: 50, city: "Chicago, IL", thumbnail: "https://resizing.flixster.com/QznwomaCPPn2qLY4qGQhpkkv95s=/679x605/v1.cjs0MzE2MjtqOzE4MDQ1OzEyMDA7Njc5OzYwNQ")
-      @dir_5 = Director.create(name: "Susan Blah", age: 42, city: "Los Angeles, CA", thumbnail: "https://thefilmstage.com/wp-content/uploads/2012/02/Brian-Kirk-to-Direct-Thor-2-300x218.jpg")
-      @dir_6 = Director.create(name: "Mike McDonald", age: 50, city: "Los Angeles, CA", thumbnail: "https://upload.wikimedia.org/wikipedia/commons/thumb/5/54/Alan_Taylor_2013_crop.jpg/440px-Alan_Taylor_2013_crop.jpg")
+      @dir_4 = Director.create!(name: "Bob Director", birth_year: 1969, city: "Chicago, IL", thumbnail: "https://resizing.flixster.com/QznwomaCPPn2qLY4qGQhpkkv95s=/679x605/v1.cjs0MzE2MjtqOzE4MDQ1OzEyMDA7Njc5OzYwNQ")
+      @dir_5 = Director.create!(name: "Susan Blah", birth_year: 1977, city: "Los Angeles, CA", thumbnail: "https://thefilmstage.com/wp-content/uploads/2012/02/Brian-Kirk-to-Direct-Thor-2-300x218.jpg")
+      @dir_6 = Director.create!(name: "Mike McDonald", birth_year: 1969, city: "Los Angeles, CA", thumbnail: "https://upload.wikimedia.org/wikipedia/commons/thumb/5/54/Alan_Taylor_2013_crop.jpg/440px-Alan_Taylor_2013_crop.jpg")
     end
 
     it "user can filter to directors with only a spec'd age" do

--- a/spec/features/directors/new_spec.rb
+++ b/spec/features/directors/new_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe "directors new page", type: :feature do
   it "user can create a new director" do
     visit "/directors/new"
     fill_in "Name", with: "Bob"
-    fill_in "Age", with: 34
+    fill_in "Birth year", with: 1985
     fill_in "City", with: "Hobbiton"
     click_on "Create Director"
 
@@ -19,7 +19,7 @@ RSpec.describe "directors new page", type: :feature do
   it "new director page reloads if invalid input" do
     visit "/directors/new"
     fill_in "Name", with: "Bob"
-    fill_in "Age", with: 34
+    fill_in "Birth year", with: 1985
     click_on "Create Director"
 
     expect(current_path).to eq("/directors/new")

--- a/spec/features/directors/statistics_spec.rb
+++ b/spec/features/directors/statistics_spec.rb
@@ -2,10 +2,10 @@ require 'rails_helper'
 
 RSpec.describe "directors index page statistics", type: :feature do
   before(:each) do
-    @dir_1 = Director.create(name: "Bob Director", age: 42, city: "Chicago, IL", thumbnail: "https://resizing.flixster.com/QznwomaCPPn2qLY4qGQhpkkv95s=/679x605/v1.cjs0MzE2MjtqOzE4MDQ1OzEyMDA7Njc5OzYwNQ")
-    @dir_2 = Director.create(name: "Susan Blah", age: 42, city: "Los Angeles, CA", thumbnail: "https://thefilmstage.com/wp-content/uploads/2012/02/Brian-Kirk-to-Direct-Thor-2-300x218.jpg")
-    @dir_3 = Director.create(name: "Mike McDonald", age: 50, city: "Los Angeles, CA", thumbnail: "https://upload.wikimedia.org/wikipedia/commons/thumb/5/54/Alan_Taylor_2013_crop.jpg/440px-Alan_Taylor_2013_crop.jpg")
-    @dir_4 = Director.create(name: "Jacob Em", age: 42, city: "Los Angeles, CA")
+    @dir_1 = Director.create(name: "Bob Director", birth_year: 1977, city: "Chicago, IL")
+    @dir_2 = Director.create(name: "Susan Blah", birth_year: 1977, city: "Los Angeles, CA")
+    @dir_3 = Director.create(name: "Mike McDonald", birth_year: 1969, city: "Los Angeles, CA")
+    @dir_4 = Director.create(name: "Jacob Em", birth_year: 1977, city: "Los Angeles, CA")
     @eps_1 = @dir_1.episodes.create(title: "The Red Wedding", viewers: 10)
     @eps_2 = @dir_1.episodes.create(title: "Battle of the Bastards", viewers: 12)
     @eps_3 = @dir_2.episodes.create(title: "Black Water Bay", viewers: 9)
@@ -26,11 +26,11 @@ RSpec.describe "directors index page statistics", type: :feature do
 
   describe "when filtering by age" do
     it "user can see age and list of all (filtered) cities" do
-      visit "/directors?age=42"
+      visit "/directors?age=#{@dir_1.age}"
 
       within "#statistics" do
         expect(page).to have_content("Statistics")
-        expect(page).to have_content("Average age: 42")
+        expect(page).to have_content("Average age: #{@dir_1.age}")
         expect(page).to have_content("All cities: Chicago, IL; Los Angeles, CA")
         expect(page).to_not have_content("Los Angeles, CA; Los Angeles, CA")
       end

--- a/spec/models/director_spec.rb
+++ b/spec/models/director_spec.rb
@@ -25,8 +25,7 @@ RSpec.describe Director, type: :model do
     end
 
     it "filters directors by age" do
-      current_year = Time.now.year
-      age_to_find = 1967 - current_year
+      age_to_find = Time.now.year - 1967
       expect(Director.filter_by_age(age_to_find).count).to eq(3)
       expect(Director.filter_by_age(age_to_find)).to include(@dir_4)
       expect(Director.filter_by_age(age_to_find)).to_not include(@dir_3)
@@ -39,7 +38,7 @@ RSpec.describe Director, type: :model do
 
       avg_age = ((@dir_1.age + @dir_2.age + @dir_3.age + @dir_4.age).to_f / 4).round(0)
 
-      expect(Director.avg_age).to eq(avg_age)
+      expect(Director.avg_age).to be_within(0.5).of(avg_age)
     end
 
     it "lists all cities" do
@@ -50,9 +49,8 @@ RSpec.describe Director, type: :model do
   describe "instance methods" do
     it "calculates age" do
       dir_1 = Director.create!(name: "Bob Director", birth_year: 2009, city: "Chicago, IL")
-      current_year = Time.now.year
 
-      expect(dir_1.age).to eq(dir_1.birth_year - current_year)
+      expect(dir_1.age).to eq(Time.now.year - dir_1.birth_year)
     end
 
     it "gives total episode count" do

--- a/spec/models/director_spec.rb
+++ b/spec/models/director_spec.rb
@@ -3,11 +3,10 @@ require 'rails_helper'
 RSpec.describe Director, type: :model do
   describe "validations" do
     it {should validate_presence_of :name}
-    # TO DO: below - change to birth_year and calculate the age
-    it {should validate_presence_of :age}
+    it {should validate_presence_of :birth_year}
     it {should validate_presence_of :city}
 
-    it {should validate_numericality_of(:age).only_integer}
+    it {should validate_numericality_of(:birth_year).only_integer}
   end
 
   describe "relationships" do
@@ -16,25 +15,27 @@ RSpec.describe Director, type: :model do
 
   describe "class methods" do
     before(:each) do
-      @dir_1 = Director.create(name: "Bob Director", age: 42, city: "Chicago, IL", thumbnail: "https://resizing.flixster.com/QznwomaCPPn2qLY4qGQhpkkv95s=/679x605/v1.cjs0MzE2MjtqOzE4MDQ1OzEyMDA7Njc5OzYwNQ")
-      @dir_2 = Director.create(name: "Susan Blah", age: 42, city: "Los Angeles, CA", thumbnail: "https://thefilmstage.com/wp-content/uploads/2012/02/Brian-Kirk-to-Direct-Thor-2-300x218.jpg")
-      @dir_3 = Director.create(name: "Mike McDonald", age: 50, city: "Los Angeles, CA", thumbnail: "https://upload.wikimedia.org/wikipedia/commons/thumb/5/54/Alan_Taylor_2013_crop.jpg/440px-Alan_Taylor_2013_crop.jpg")
-      @dir_4 = Director.create(name: "Jacob Em", age: 42, city: "Aaa")
+      @dir_1 = Director.create(name: "Bob Director", birth_year: 1967, city: "Chicago, IL", thumbnail: "https://resizing.flixster.com/QznwomaCPPn2qLY4qGQhpkkv95s=/679x605/v1.cjs0MzE2MjtqOzE4MDQ1OzEyMDA7Njc5OzYwNQ")
+      @dir_2 = Director.create(name: "Susan Blah", birth_year: 1967, city: "Los Angeles, CA", thumbnail: "https://thefilmstage.com/wp-content/uploads/2012/02/Brian-Kirk-to-Direct-Thor-2-300x218.jpg")
+      @dir_3 = Director.create(name: "Mike McDonald", birth_year: 1974, city: "Los Angeles, CA", thumbnail: "https://upload.wikimedia.org/wikipedia/commons/thumb/5/54/Alan_Taylor_2013_crop.jpg/440px-Alan_Taylor_2013_crop.jpg")
+      @dir_4 = Director.create(name: "Jacob Em", birth_year: 1967, city: "Aaa")
       @eps_1 = @dir_1.episodes.create(title: "The Red Wedding", viewers: 10)
       @eps_2 = @dir_1.episodes.create(title: "Battle of the Bastards", viewers: 12)
       @eps_3 = @dir_2.episodes.create(title: "Black Water Bay", viewers: 9)
     end
 
     it "filters directors by age" do
-      expect(Director.filter_by_age(42).count).to eq(3)
-      expect(Director.filter_by_age(42)).to include(@dir_4)
-      expect(Director.filter_by_age(42)).to_not include(@dir_3)
+      current_year = Time.now.year
+      age_to_find = 1967 - current_year
+      expect(Director.filter_by_age(age_to_find).count).to eq(3)
+      expect(Director.filter_by_age(age_to_find)).to include(@dir_4)
+      expect(Director.filter_by_age(age_to_find)).to_not include(@dir_3)
 
       expect(Director.filter_by_age("zebra").count).to eq(0)
     end
 
     it "calculates average director age" do
-      Director.create(name: "Don't Add Me", age: "zebra", city: "Los Angeles, CA")
+      Director.create(name: "Don't Add Me", birth_year: "zebra", city: "Los Angeles, CA")
 
       avg_age = ((@dir_1.age + @dir_2.age + @dir_3.age + @dir_4.age).to_f / 4).round(0)
 
@@ -47,10 +48,17 @@ RSpec.describe Director, type: :model do
   end
 
   describe "instance methods" do
+    it "calculates age" do
+      dir_1 = Director.create!(name: "Bob Director", birth_year: 2009, city: "Chicago, IL")
+      current_year = Time.now.year
+
+      expect(dir_1.age).to eq(dir_1.birth_year - current_year)
+    end
+
     it "gives total episode count" do
-      dir_1 = Director.create(name: "Bob Director", age: 42, city: "Chicago, IL", thumbnail: "https://resizing.flixster.com/QznwomaCPPn2qLY4qGQhpkkv95s=/679x605/v1.cjs0MzE2MjtqOzE4MDQ1OzEyMDA7Njc5OzYwNQ")
-      dir_2 = Director.create(name: "Susan Blah", age: 42, city: "Los Angeles, CA", thumbnail: "https://thefilmstage.com/wp-content/uploads/2012/02/Brian-Kirk-to-Direct-Thor-2-300x218.jpg")
-      dir_3 = Director.create(name: "Mike McDonald", age: 50, city: "Los Angeles, CA", thumbnail: "https://upload.wikimedia.org/wikipedia/commons/thumb/5/54/Alan_Taylor_2013_crop.jpg/440px-Alan_Taylor_2013_crop.jpg")
+      dir_1 = Director.create(name: "Bob Director", birth_year: 1967, city: "Chicago, IL")
+      dir_2 = Director.create(name: "Susan Blah", birth_year: 1967, city: "Los Angeles, CA")
+      dir_3 = Director.create(name: "Mike McDonald", birth_year: 1974, city: "Los Angeles, CA")
       eps_1 = dir_1.episodes.create(title: "The Red Wedding", viewers: 10)
       eps_2 = dir_1.episodes.create(title: "Battle of the Bastards", viewers: 12)
       eps_3 = dir_2.episodes.create(title: "Black Water Bay", viewers: 9)


### PR DESCRIPTION
This PR/branch...
 - Stores the directors' birth years instead of ages and updates the app accordingly:
   - `Director` model
   - All tests
   - Views (`directors/index` & `directors/new`)
   - `DirectorsController`
   - `directors` table & seeds