### PR TITLE
Expanded stats

### DIFF
--- a/app/controllers/directors_controller.rb
+++ b/app/controllers/directors_controller.rb
@@ -6,15 +6,16 @@ class DirectorsController < ApplicationController
     else
       @directors = Director.filter_by_age(age)
     end
+    sortable = ["age", "city", "name"]
+    if sortable.include?(params[:sort])
+      params[:sort] == "age" ? sort_by = "birth_year" : sort_by = params[:sort]
+      @directors = @directors.order(sort_by.to_sym)
+    end
     @director_count = @directors.count
     @director_avg_age = @directors.avg_age
     @all_director_cities = @directors.all_uniq_cities
     @episode_count = @directors.episode_count
-    # if @director_count > 0
-      @avg_viewers = @directors.avg_viewers
-    # else
-    #   @avg_viewers = 0
-    # end
+    @avg_viewers = @directors.avg_viewers
   end
 
   def new

--- a/app/controllers/directors_controller.rb
+++ b/app/controllers/directors_controller.rb
@@ -9,6 +9,7 @@ class DirectorsController < ApplicationController
     @director_count = @directors.count
     @director_avg_age = @directors.avg_age
     @all_director_cities = @directors.all_uniq_cities
+    @episode_count = @directors.episode_count
   end
 
   def new

--- a/app/controllers/directors_controller.rb
+++ b/app/controllers/directors_controller.rb
@@ -10,6 +10,11 @@ class DirectorsController < ApplicationController
     @director_avg_age = @directors.avg_age
     @all_director_cities = @directors.all_uniq_cities
     @episode_count = @directors.episode_count
+    # if @director_count > 0
+      @avg_viewers = @directors.avg_viewers
+    # else
+    #   @avg_viewers = 0
+    # end
   end
 
   def new

--- a/app/models/director.rb
+++ b/app/models/director.rb
@@ -21,7 +21,7 @@ class Director < ApplicationRecord
   end
 
   def self.all_uniq_cities
-    distinct.pluck(:city).sort
+    pluck(:city).uniq.sort
   end
 
   def self.episode_count

--- a/app/models/director.rb
+++ b/app/models/director.rb
@@ -28,6 +28,10 @@ class Director < ApplicationRecord
     joins(:episodes).count
   end
 
+  def self.avg_viewers
+    joins(:episodes).average(:viewers)
+  end
+
   def age
     if birth_year.nil?
       nil

--- a/app/models/director.rb
+++ b/app/models/director.rb
@@ -24,6 +24,10 @@ class Director < ApplicationRecord
     distinct.pluck(:city).sort
   end
 
+  def self.episode_count
+    joins(:episodes).count
+  end
+
   def age
     if birth_year.nil?
       nil

--- a/app/views/directors/index.html.erb
+++ b/app/views/directors/index.html.erb
@@ -17,6 +17,7 @@
  <div id="statistics">
    <h2>Statistics</h2>
    <p>Average age: <%= @director_avg_age.round(0).to_i %></p>
+   <p>Total episode count: <%= @episode_count %></p>
    <p>All cities:
      <% @all_director_cities.each do |city| %>
       <%= " #{city}#{";" if city != @all_director_cities.last}" %>

--- a/app/views/directors/index.html.erb
+++ b/app/views/directors/index.html.erb
@@ -32,10 +32,12 @@
 <div class="card-deck">
   <% @directors.each do |director| %>
     <div class="card director-card" id="director-<%= director.id %>">
-      <img src="<%= director.thumbnail %>" class="card-img-top director-thumbnail" alt="<%= director.name %> thumbnail">
+      <% if !director.thumbnail.nil? %>
+        <img src="<%= director.thumbnail %>" class="card-img-top director-thumbnail" alt="<%= director.name %> thumbnail">
+      <% end %>
       <div class="card-body">
         <h3 class="card-title"><%= director.name %></h3>
-        <p class="card-text"><%= director.age %></p>
+        <p class="card-text">Age: <%= director.age %></p>
         <p class="card-text"><%= director.city %></p>
 
         <% if director.episode_count > 0 %>

--- a/app/views/directors/index.html.erb
+++ b/app/views/directors/index.html.erb
@@ -18,6 +18,9 @@
    <h2>Statistics</h2>
    <p>Average age: <%= @director_avg_age.round(0).to_i %></p>
    <p>Total episode count: <%= @episode_count %></p>
+   <% if @episode_count > 0 %>
+     <p>Average viewers per episode: <%= @avg_viewers.round(1) %> million</p>
+   <% end %>
    <p>All cities:
      <% @all_director_cities.each do |city| %>
       <%= " #{city}#{";" if city != @all_director_cities.last}" %>

--- a/spec/features/directors/index_spec.rb
+++ b/spec/features/directors/index_spec.rb
@@ -70,6 +70,30 @@ RSpec.describe "directors index page", type: :feature do
         expect(page).to have_no_content("Episodes")
       end
     end
+
+    it "user can sort the directors by name" do
+      visit "/directors?sort=name"
+
+      expect(page).to have_content(@dir_1.name)
+      expect(page).to have_content(@dir_3.name)
+      expect(page).to have_content(@dir_2.name)
+    end
+
+    it "user can sort the directors by age" do
+      visit "/directors?sort=age"
+
+      expect(page).to have_content(@dir_1.name)
+      expect(page).to have_content(@dir_3.name)
+      expect(page).to have_content(@dir_2.name)
+    end
+
+    it "user can sort the directors by city" do
+      visit "/directors?sort=city"
+
+      expect(page).to have_content(@dir_1.name)
+      expect(page).to have_content(@dir_2.name)
+      expect(page).to have_content(@dir_3.name)
+    end
   end
 
   describe "when filtering by age" do

--- a/spec/features/directors/statistics_spec.rb
+++ b/spec/features/directors/statistics_spec.rb
@@ -32,6 +32,15 @@ RSpec.describe "directors index page statistics", type: :feature do
     end
   end
 
+  it "user can see avg viewers per episode" do
+    visit "/directors"
+
+    within "#statistics" do
+      avg_expected = (@eps_1.viewers + @eps_2.viewers + @eps_3.viewers).to_f / 3
+      expect(page).to have_content("Average viewers per episode: #{avg_expected.round(1)} million")
+    end
+  end
+
   describe "when filtering by age" do
     it "user can see age and list of all (filtered) cities" do
       visit "/directors?age=#{@dir_1.age}"

--- a/spec/features/directors/statistics_spec.rb
+++ b/spec/features/directors/statistics_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe "directors index page statistics", type: :feature do
     @dir_4 = Director.create(name: "Jacob Em", birth_year: 1977, city: "Los Angeles, CA")
     @eps_1 = @dir_1.episodes.create(title: "The Red Wedding", viewers: 10)
     @eps_2 = @dir_1.episodes.create(title: "Battle of the Bastards", viewers: 12)
-    @eps_3 = @dir_2.episodes.create(title: "Black Water Bay", viewers: 9)
+    @eps_3 = @dir_3.episodes.create(title: "Black Water Bay", viewers: 9)
   end
 
   it "user can see average age and list of all cities" do
@@ -24,6 +24,14 @@ RSpec.describe "directors index page statistics", type: :feature do
     end
   end
 
+  it "user can see total episode count" do
+    visit "/directors"
+
+    within "#statistics" do
+      expect(page).to have_content("Total episode count: #{Episode.count}")
+    end
+  end
+
   describe "when filtering by age" do
     it "user can see age and list of all (filtered) cities" do
       visit "/directors?age=#{@dir_1.age}"
@@ -33,6 +41,14 @@ RSpec.describe "directors index page statistics", type: :feature do
         expect(page).to have_content("Average age: #{@dir_1.age}")
         expect(page).to have_content("All cities: Chicago, IL; Los Angeles, CA")
         expect(page).to_not have_content("Los Angeles, CA; Los Angeles, CA")
+      end
+    end
+
+    it "user can see total episode count" do
+      visit "/directors?age=#{@dir_1.age}"
+
+      within "#statistics" do
+        expect(page).to have_content("Total episode count: 2")
       end
     end
   end

--- a/spec/models/director_spec.rb
+++ b/spec/models/director_spec.rb
@@ -48,6 +48,11 @@ RSpec.describe Director, type: :model do
     it "counts all episodes" do
       expect(Director.episode_count).to eq(3)
     end
+
+    it "calculates average viewers per episode" do
+      avg_expected = (@eps_1.viewers + @eps_2.viewers + @eps_3.viewers).to_f / 3
+      expect(Director.avg_viewers).to be_within(0.5).of(avg_expected)
+    end
   end
 
   describe "instance methods" do

--- a/spec/models/director_spec.rb
+++ b/spec/models/director_spec.rb
@@ -44,6 +44,10 @@ RSpec.describe Director, type: :model do
     it "lists all cities" do
       expect(Director.all_uniq_cities).to eq(["Aaa", "Chicago, IL", "Los Angeles, CA"])
     end
+
+    it "counts all episodes" do
+      expect(Director.episode_count).to eq(3)
+    end
   end
 
   describe "instance methods" do


### PR DESCRIPTION
This branch/PR...
 - Calculates the total episode count for all (or a subset of) directors & displays it
 - Calculates the average viewers for all (or a subset of) episodes & displays it
 - Adds ability to sort directors by name, age, or birth date
 - Only displays the director's thumbnail image if there is one